### PR TITLE
fix inserting/extracting only taking 16/32 items

### DIFF
--- a/src/main/java/uk/co/hexeption/aeinfinitybooster/mixins/MixinWirelessTerminalMenuHost.java
+++ b/src/main/java/uk/co/hexeption/aeinfinitybooster/mixins/MixinWirelessTerminalMenuHost.java
@@ -2,17 +2,13 @@ package uk.co.hexeption.aeinfinitybooster.mixins;
 
 import appeng.api.implementations.blockentities.IWirelessAccessPoint;
 import appeng.api.implementations.menuobjects.ItemMenuHost;
-import appeng.api.networking.IGrid;
 import appeng.blockentity.networking.WirelessAccessPointBlockEntity;
 import appeng.helpers.WirelessTerminalMenuHost;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import uk.co.hexeption.aeinfinitybooster.setup.ModItems;
 
@@ -24,8 +20,6 @@ import uk.co.hexeption.aeinfinitybooster.setup.ModItems;
  */
 @Mixin(value = WirelessTerminalMenuHost.class, remap = false)
 public class MixinWirelessTerminalMenuHost extends ItemMenuHost {
-
-    @Shadow @Final private IGrid targetGrid;
 
     public MixinWirelessTerminalMenuHost(Player player, int slot, ItemStack itemStack) {
         super(player, slot, itemStack);

--- a/src/main/java/uk/co/hexeption/aeinfinitybooster/mixins/MixinWirelessTerminalMenuHost.java
+++ b/src/main/java/uk/co/hexeption/aeinfinitybooster/mixins/MixinWirelessTerminalMenuHost.java
@@ -25,9 +25,6 @@ import uk.co.hexeption.aeinfinitybooster.setup.ModItems;
 @Mixin(value = WirelessTerminalMenuHost.class, remap = false)
 public class MixinWirelessTerminalMenuHost extends ItemMenuHost {
 
-    @Shadow
-    private double currentDistanceFromGrid;
-
     @Shadow @Final private IGrid targetGrid;
 
     public MixinWirelessTerminalMenuHost(Player player, int slot, ItemStack itemStack) {
@@ -40,8 +37,7 @@ public class MixinWirelessTerminalMenuHost extends ItemMenuHost {
         wirelessAccessPoint.getGrid().getMachines(WirelessAccessPointBlockEntity.class).forEach(wirelessBlockEntity -> {
 
             if (wirelessBlockEntity.getInternalInventory().getStackInSlot(0).is(ModItems.DIMENSION_CARD.get())) {
-                currentDistanceFromGrid = 32;
-                cir.setReturnValue(Double.MAX_VALUE / 2);
+                cir.setReturnValue(1024.0D);
             }
 
             if (!this.getPlayer().level().dimension().location().toString().equals(wirelessAccessPoint.getLocation().getLevel().dimension().location().toString())) {
@@ -49,24 +45,8 @@ public class MixinWirelessTerminalMenuHost extends ItemMenuHost {
             }
 
             if (wirelessBlockEntity.getInternalInventory().getStackInSlot(0).is(ModItems.INFINITY_CARD.get())) {
-                currentDistanceFromGrid = 16;
-                cir.setReturnValue(Double.MAX_VALUE / 2);
+                cir.setReturnValue(256.0D);
             }
         });
     }
-
-    // Make sure we don't use more power than we should
-    @Redirect(method = "extractAEPower", at = @At(value = "INVOKE", target = "Ljava/lang/Math;min(DD)D"))
-    private double testPowerMultiplier(double a, double b) {
-        for (var wap : this.targetGrid.getMachines(WirelessAccessPointBlockEntity.class)) {
-            if (wap.getInternalInventory().getStackInSlot(0).is(ModItems.INFINITY_CARD.get())) {
-                return 16;
-            }
-            if (wap.getInternalInventory().getStackInSlot(0).is(ModItems.DIMENSION_CARD.get())) {
-                return 32;
-            }
-        }
-        return Math.min(a, b);
-    }
-
 }


### PR DESCRIPTION
Fixes #14 by removing the power consuption override code and instead tricking the ME system into thinking that the wireless terminal is only 16 block away (or 32 for dimension card). Please note that this increases the passive power consuption from 16/32 per 11 ticks to 16/32 per tick, effectively multiplying power consumption by 11. This could be returned back to the old behavior fairly easy by changing the faked distance.