### PR TITLE
Don't log the creation of the creative tab at listener registration

### DIFF
--- a/src/main/java/uk/co/hexeption/aeinfinitybooster/AEInfinityBooster.java
+++ b/src/main/java/uk/co/hexeption/aeinfinitybooster/AEInfinityBooster.java
@@ -61,8 +61,9 @@ public class AEInfinityBooster {
                 )
                 .title(Component.translatable("item_group." + ID + ".tab"))
                 .build();
-        LOGGER.info("Creating Creative Mode Tab");
-        Registry.register(registry, new ResourceLocation(ID, "aeinfinitybooster"), tab);
+        ResourceLocation id = new ResourceLocation(ID, "aeinfinitybooster");
+        LOGGER.debug("Creating Creative Mode Tab '" + id + "'");
+        Registry.register(registry, id, tab);
     }
 
 }

--- a/src/main/java/uk/co/hexeption/aeinfinitybooster/AEInfinityBooster.java
+++ b/src/main/java/uk/co/hexeption/aeinfinitybooster/AEInfinityBooster.java
@@ -35,7 +35,6 @@ public class AEInfinityBooster {
 
         IEventBus eventBus = FMLJavaModLoadingContext.get().getModEventBus();
         eventBus.addListener((RegisterEvent event) -> {
-            LOGGER.info("Creating Creative Mode Tab");
             if(event.getRegistryKey() == Registries.CREATIVE_MODE_TAB){
                 registerTab(event.getVanillaRegistry());
             }
@@ -62,6 +61,7 @@ public class AEInfinityBooster {
                 )
                 .title(Component.translatable("item_group." + ID + ".tab"))
                 .build();
+        LOGGER.info("Creating Creative Mode Tab");
         Registry.register(registry, new ResourceLocation(ID, "aeinfinitybooster"), tab);
     }
 


### PR DESCRIPTION
Before, when forge tried to add an `RegisterEvent`, it would call `addListener`. But since `addListener((RegisterEvent event)...` can be called for multiple register event types, it would log the message also multiple times. 
![image](https://github.com/Hexeption/AEInfinityBooster/assets/67484093/0c0e1da5-b7c3-446f-a7de-d44656be880c)


I moved the logging to the actual place where the creative tab registers itself 